### PR TITLE
Flush all aggregates and buffer on exit

### DIFF
--- a/src/ngx_http_statshouse_module.c
+++ b/src/ngx_http_statshouse_module.c
@@ -1282,5 +1282,20 @@ ngx_http_statshouse_flush_server(ngx_cycle_t *cycle, ngx_http_core_srv_conf_t *s
 static void
 ngx_http_statshouse_exit_process(ngx_cycle_t *cycle)
 {
-    ngx_statshouse_aggregate_exit_process_handler(cycle);
+    ngx_http_statshouse_main_conf_t   *smcf;
+    ngx_statshouse_server_t          **servers;
+    ngx_uint_t                         i;
+
+    smcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_statshouse_module);
+    if (smcf->servers == NULL || smcf->confs == NULL) {
+        return;
+    }
+
+    ngx_log_debug0(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+        "statshouse http: flushing all aggregates on exit process");
+
+    servers = smcf->servers->elts;
+    for (i = 0; i < smcf->servers->nelts; i++) {
+        ngx_statshouse_exit_handler(servers[i]);
+    }
 }

--- a/src/ngx_http_statshouse_module.c
+++ b/src/ngx_http_statshouse_module.c
@@ -56,6 +56,8 @@ static char *      ngx_http_statshouse_server_slot(ngx_conf_t *cf, ngx_command_t
 
 static ngx_int_t   ngx_http_statshouse_handler(ngx_http_request_t *request);
 
+static void        ngx_http_statshouse_exit_process(ngx_cycle_t *cycle);
+
 
 static ngx_command_t  ngx_http_statshouse_commands[] = {
     { ngx_string("statshouse_server"),
@@ -329,7 +331,7 @@ ngx_module_t  ngx_http_statshouse_module = {
     NULL,                                    /* init process */
     NULL,                                    /* init thread */
     NULL,                                    /* exit thread */
-    NULL,                                    /* exit process */
+    ngx_http_statshouse_exit_process,        /* exit process */
     NULL,                                    /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -1277,3 +1279,8 @@ ngx_http_statshouse_flush_server(ngx_cycle_t *cycle, ngx_http_core_srv_conf_t *s
     return ngx_http_statshouse_flush_ctx(cycle, ctx, pool);
 }
 
+static void
+ngx_http_statshouse_exit_process(ngx_cycle_t *cycle)
+{
+    ngx_statshouse_aggregate_exit_process_handler(cycle);
+}

--- a/src/ngx_statshouse.c
+++ b/src/ngx_statshouse.c
@@ -665,3 +665,16 @@ ngx_statshouse_aggregate_handler(ngx_statshouse_stat_t *stat, void *ctx)
 
     return ngx_statshouse_send_to_buffer(server, stat);
 }
+
+ngx_int_t
+ngx_statshouse_exit_handler(ngx_statshouse_server_t *server)
+{
+    ngx_msec_t now;
+
+    if (server && server->aggregate) {
+        now = ngx_current_msec;
+        return ngx_statshouse_aggregate_process(server->aggregate, now);
+    }
+
+    return NGX_OK;
+}

--- a/src/ngx_statshouse.c
+++ b/src/ngx_statshouse.c
@@ -242,10 +242,6 @@ ngx_statshouse_flush(ngx_statshouse_server_t *server)
         ngx_log_debug2(NGX_LOG_DEBUG_CORE, server->log, 0,
             "statshouse send %z bytes: %V", n, &server->addr.addrs->name);
 
-        if (ngx_terminate || ngx_exiting) {
-            ngx_statshouse_disconnect(server);
-        }
-
         server->buffer->last = server->buffer->pos;
         return NGX_OK;
     }
@@ -671,10 +667,17 @@ ngx_statshouse_exit_handler(ngx_statshouse_server_t *server)
 {
     ngx_msec_t now;
 
-    if (server && server->aggregate) {
-        now = ngx_current_msec;
-        return ngx_statshouse_aggregate_process(server->aggregate, now);
+    if (server == NULL) {
+        return NGX_OK;
     }
+
+    if (server->aggregate) {
+        now = ngx_current_msec;
+        ngx_statshouse_aggregate_process(server->aggregate, now);
+    }
+
+    ngx_statshouse_flush(server);
+    ngx_statshouse_disconnect(server);
 
     return NGX_OK;
 }

--- a/src/ngx_statshouse.h
+++ b/src/ngx_statshouse.h
@@ -95,5 +95,6 @@ ngx_int_t  ngx_statshouse_flush_after_request(ngx_statshouse_server_t *server);
 ngx_int_t  ngx_statshouse_stat_compile(ngx_statshouse_conf_t *conf, ngx_statshouse_stat_t *stats, ngx_int_t max,
     ngx_statshouse_complex_value_pt complex, void *complex_ctx, ngx_log_t *log);
 
+ngx_int_t  ngx_statshouse_exit_handler(ngx_statshouse_server_t *server);
 
 #endif

--- a/src/ngx_statshouse_aggregate.c
+++ b/src/ngx_statshouse_aggregate.c
@@ -24,12 +24,16 @@ typedef struct {
 
 static void  ngx_statshouse_aggregate_timer_handler(ngx_event_t *ev);
 static void  ngx_statshouse_aggregate_timer(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t now);
+static void  ngx_statshouse_aggregate_exit_process(ngx_cycle_t *cycle);
 
 static void  ngx_statshouse_aggregate_insert_value(ngx_rbtree_node_t *temp, ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 static ngx_statshouse_aggregate_stat_t  *ngx_statshouse_aggregate_lookup(ngx_statshouse_aggregate_t *server,
     uint32_t hash, size_t size, ngx_int_t type);
 static void  *ngx_statshouse_aggregate_alloc(ngx_statshouse_aggregate_t *aggregate, size_t size);
 static void  ngx_statshouse_aggregate_free(ngx_statshouse_aggregate_t *aggregate, void *ptr, size_t size);
+
+
+static ngx_array_t *ngx_statshouse_aggregates = NULL;
 
 
 ngx_int_t
@@ -54,6 +58,22 @@ ngx_statshouse_aggregate_init(ngx_statshouse_aggregate_t *aggregate, ngx_pool_t 
 
     aggregate->timer_connection.fd = -1;
     aggregate->timer_connection.data = aggregate;
+
+    /* Register aggregate for process exit handler */
+    if (ngx_statshouse_aggregates == NULL) {
+        ngx_statshouse_aggregates = ngx_array_create(pool, 4, sizeof(ngx_statshouse_aggregate_t *));
+        if (ngx_statshouse_aggregates == NULL) {
+            return NGX_ERROR;
+        }
+    }
+
+    {
+        ngx_statshouse_aggregate_t **agg = ngx_array_push(ngx_statshouse_aggregates);
+        if (agg == NULL) {
+            return NGX_ERROR;
+        }
+        *agg = aggregate;
+    }
 
     return NGX_OK;
 }
@@ -287,6 +307,31 @@ ngx_statshouse_aggregate_timer(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t
 
 
 static void
+ngx_statshouse_aggregate_exit_process(ngx_cycle_t *cycle)
+{
+    ngx_statshouse_aggregate_t  **aggregates;
+    ngx_uint_t                   i;
+    ngx_msec_t                   now;
+
+    if (ngx_statshouse_aggregates == NULL) {
+        return;
+    }
+
+    now = ngx_current_msec;
+    aggregates = ngx_statshouse_aggregates->elts;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+        "statshouse aggregate exit process: flushing all aggregates");
+
+    for (i = 0; i < ngx_statshouse_aggregates->nelts; i++) {
+        if (aggregates[i] != NULL) {
+            ngx_statshouse_aggregate_process(aggregates[i], now);
+        }
+    }
+}
+
+
+static void
 ngx_statshouse_aggregate_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
 {
@@ -419,4 +464,11 @@ ngx_statshouse_aggregate_free(ngx_statshouse_aggregate_t *aggregate, void *ptr, 
     }
 
     aggregate->alloc.last += size;
+}
+
+
+void
+ngx_statshouse_aggregate_exit_process_handler(ngx_cycle_t *cycle)
+{
+    ngx_statshouse_aggregate_exit_process(cycle);
 }

--- a/src/ngx_statshouse_aggregate.c
+++ b/src/ngx_statshouse_aggregate.c
@@ -24,16 +24,12 @@ typedef struct {
 
 static void  ngx_statshouse_aggregate_timer_handler(ngx_event_t *ev);
 static void  ngx_statshouse_aggregate_timer(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t now);
-static void  ngx_statshouse_aggregate_exit_process(ngx_cycle_t *cycle);
 
 static void  ngx_statshouse_aggregate_insert_value(ngx_rbtree_node_t *temp, ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 static ngx_statshouse_aggregate_stat_t  *ngx_statshouse_aggregate_lookup(ngx_statshouse_aggregate_t *server,
     uint32_t hash, size_t size, ngx_int_t type);
 static void  *ngx_statshouse_aggregate_alloc(ngx_statshouse_aggregate_t *aggregate, size_t size);
 static void  ngx_statshouse_aggregate_free(ngx_statshouse_aggregate_t *aggregate, void *ptr, size_t size);
-
-
-static ngx_array_t *ngx_statshouse_aggregates = NULL;
 
 
 ngx_int_t
@@ -58,22 +54,6 @@ ngx_statshouse_aggregate_init(ngx_statshouse_aggregate_t *aggregate, ngx_pool_t 
 
     aggregate->timer_connection.fd = -1;
     aggregate->timer_connection.data = aggregate;
-
-    /* Register aggregate for process exit handler */
-    if (ngx_statshouse_aggregates == NULL) {
-        ngx_statshouse_aggregates = ngx_array_create(pool, 4, sizeof(ngx_statshouse_aggregate_t *));
-        if (ngx_statshouse_aggregates == NULL) {
-            return NGX_ERROR;
-        }
-    }
-
-    {
-        ngx_statshouse_aggregate_t **agg = ngx_array_push(ngx_statshouse_aggregates);
-        if (agg == NULL) {
-            return NGX_ERROR;
-        }
-        *agg = aggregate;
-    }
 
     return NGX_OK;
 }
@@ -307,31 +287,6 @@ ngx_statshouse_aggregate_timer(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t
 
 
 static void
-ngx_statshouse_aggregate_exit_process(ngx_cycle_t *cycle)
-{
-    ngx_statshouse_aggregate_t  **aggregates;
-    ngx_uint_t                   i;
-    ngx_msec_t                   now;
-
-    if (ngx_statshouse_aggregates == NULL) {
-        return;
-    }
-
-    now = ngx_current_msec;
-    aggregates = ngx_statshouse_aggregates->elts;
-
-    ngx_log_debug0(NGX_LOG_DEBUG_CORE, cycle->log, 0,
-        "statshouse aggregate exit process: flushing all aggregates");
-
-    for (i = 0; i < ngx_statshouse_aggregates->nelts; i++) {
-        if (aggregates[i] != NULL) {
-            ngx_statshouse_aggregate_process(aggregates[i], now);
-        }
-    }
-}
-
-
-static void
 ngx_statshouse_aggregate_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
 {
@@ -464,11 +419,4 @@ ngx_statshouse_aggregate_free(ngx_statshouse_aggregate_t *aggregate, void *ptr, 
     }
 
     aggregate->alloc.last += size;
-}
-
-
-void
-ngx_statshouse_aggregate_exit_process_handler(ngx_cycle_t *cycle)
-{
-    ngx_statshouse_aggregate_exit_process(cycle);
 }

--- a/src/ngx_statshouse_aggregate.h
+++ b/src/ngx_statshouse_aggregate.h
@@ -41,6 +41,5 @@ typedef struct {
 ngx_int_t  ngx_statshouse_aggregate_init(ngx_statshouse_aggregate_t *aggregate, ngx_pool_t *pool);
 ngx_int_t  ngx_statshouse_aggregate(ngx_statshouse_aggregate_t *aggregate, ngx_statshouse_stat_t *stat, ngx_msec_t now);
 ngx_int_t  ngx_statshouse_aggregate_process(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t now);
-void       ngx_statshouse_aggregate_exit_process_handler(ngx_cycle_t *cycle);
 
 #endif

--- a/src/ngx_statshouse_aggregate.h
+++ b/src/ngx_statshouse_aggregate.h
@@ -41,5 +41,6 @@ typedef struct {
 ngx_int_t  ngx_statshouse_aggregate_init(ngx_statshouse_aggregate_t *aggregate, ngx_pool_t *pool);
 ngx_int_t  ngx_statshouse_aggregate(ngx_statshouse_aggregate_t *aggregate, ngx_statshouse_stat_t *stat, ngx_msec_t now);
 ngx_int_t  ngx_statshouse_aggregate_process(ngx_statshouse_aggregate_t *aggregate, ngx_msec_t now);
+void       ngx_statshouse_aggregate_exit_process_handler(ngx_cycle_t *cycle);
 
 #endif

--- a/src/ngx_stream_statshouse_module.c
+++ b/src/ngx_stream_statshouse_module.c
@@ -1114,5 +1114,20 @@ ngx_stream_statshouse_flush_server(ngx_cycle_t *cycle, ngx_stream_core_srv_conf_
 static void
 ngx_stream_statshouse_exit_process(ngx_cycle_t *cycle)
 {
-    ngx_statshouse_aggregate_exit_process_handler(cycle);
+    ngx_stream_statshouse_main_conf_t   *smcf;
+    ngx_statshouse_server_t          **servers;
+    ngx_uint_t                         i;
+
+    smcf = ngx_stream_cycle_get_module_main_conf(cycle, ngx_stream_statshouse_module);
+    if (smcf->servers == NULL || smcf->confs == NULL) {
+        return;
+    }
+
+    ngx_log_debug0(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+        "statshouse stream: flushing all aggregates on exit process");
+
+    servers = smcf->servers->elts;
+    for (i = 0; i < smcf->servers->nelts; i++) {
+        ngx_statshouse_exit_handler(servers[i]);
+    }
 }

--- a/src/ngx_stream_statshouse_module.c
+++ b/src/ngx_stream_statshouse_module.c
@@ -54,6 +54,8 @@ static char *      ngx_stream_statshouse_server_slot(ngx_conf_t *cf, ngx_command
 
 static ngx_int_t   ngx_stream_statshouse_handler(ngx_stream_session_t *session);
 
+static void        ngx_stream_statshouse_exit_process(ngx_cycle_t *cycle);
+
 
 static ngx_command_t  ngx_stream_statshouse_commands[] = {
     { ngx_string("statshouse_server"),
@@ -314,7 +316,7 @@ ngx_module_t  ngx_stream_statshouse_module = {
     NULL,                                    /* init process */
     NULL,                                    /* init thread */
     NULL,                                    /* exit thread */
-    NULL,                                    /* exit process */
+    ngx_stream_statshouse_exit_process,      /* exit process */
     NULL,                                    /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -1109,3 +1111,8 @@ ngx_stream_statshouse_flush_server(ngx_cycle_t *cycle, ngx_stream_core_srv_conf_
     return ngx_stream_statshouse_flush_ctx(cycle, ctx, pool);
 }
 
+static void
+ngx_stream_statshouse_exit_process(ngx_cycle_t *cycle)
+{
+    ngx_statshouse_aggregate_exit_process_handler(cycle);
+}


### PR DESCRIPTION
Flush all aggregates and buffer on exit.
Also PR fixes the problem with multiple connect+disconnect during exit.